### PR TITLE
Move `ObjectDestroy` to namespace `vk::detail`

### DIFF
--- a/include/vkfw/vkfw.hpp
+++ b/include/vkfw/vkfw.hpp
@@ -3073,7 +3073,8 @@ namespace VKFW_NAMESPACE {
     VkSurfaceKHR output;
     glfwCreateWindowSurface(instance, window, allocator, &output);
 
-    vk::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> deleter(instance, nullptr);
+    vk::detail::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> deleter(instance,
+                                                                                        nullptr);
     return vk::UniqueSurfaceKHR(output, deleter);
   }
     #endif


### PR DESCRIPTION
This is just a simple fix as what's described in #7. Maybe this can be better handled by checking the version number of the `vulkan.hpp` header file.