### PR TITLE
Add CMake integration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,108 @@
+cmake_minimum_required(VERSION 3.20)
+project(vkfw LANGUAGES CXX)
+
+# Build options.
+option(VKFW_FETCH_DEPENDENCIES "Fetch build dependencies" OFF)
+option(VKFW_INSTALL "Create install target" OFF)
+option(VKFW_BUILD_EXAMPLES "Build examples" OFF)
+
+# Configuration options
+option(VKFW_DISABLE_ENHANCED_MODE "Disable enhanced functionality" OFF)
+option(VKFW_NO_EXCEPTIONS "Disable exceptions" OFF)
+option(VKFW_NO_SMART_HANDLE "Disable UniqueHandles" OFF)
+option(VKFW_NO_STD_FUNCTION_CALLBACKS "Disable std::function callbacks" OFF)
+option(VKFW_NO_NODISCARD_WARNINGS "Disable [[nodiscard]] warnings" OFF)
+option(VKFW_NO_INCLUDE_VULKAN "Disable includsion of vulkan.h" OFF)
+option(VKFW_INCLUDE_GL "Include OpenGL headers" OFF)
+option(VKFW_NO_INCLUDE_VULKAN_HPP "Disable inclusion of vulkan.hpp" OFF)
+option(VKFW_NO_LEADING_E_IN_ENUMS "Disable leading e prefix in enums" OFF)
+option(VKFW_NO_STRUCT_CONSTRUCTORS "Disable constructors for structs" OFF)
+option(VKFW_NO_SPACESHIP_OPERATOR "Disable spaceship comparison" OFF)
+option(VKFW_NO_STRING_VIEW "Disable usage of std::string_view" OFF)
+option(VKFW_NO_SPAN "Disable usage of std::span" OFF)
+
+set(VKFW_SOURCE_DIR ${PROJECT_SOURCE_DIR})
+set(VKFW_SOURCE_ROOT ${VKFW_SOURCE_DIR}/include)
+set(VKFW_EXAMPLE_ROOT ${VKFW_SOURCE_DIR}/example)
+set(VKFW_DEPS_ROOT ${VKFW_SOURCE_DIR}/deps)
+
+# This the version of GLFW that will be fetched either through VKFW_FETCH_DEPENDENCIES or
+# by the examples (if VKFW_BUILD_EXAMPLES is set). See ./example/CMakeLists.txt for
+# details.
+set(VKFW_GLFW_FETCH_VERSION 3.4)
+
+find_package(glfw3 QUIET)
+if (NOT glfw3_FOUND AND VKFW_FETCH_DEPENDENCIES)
+    include(FetchContent)
+    FetchContent_Declare(
+        glfw3
+        GIT_REPOSITORY https://github.com/glfw/glfw
+        GIT_TAG ${VKFW_GLFW_FETCH_VERSION}
+    )
+    FetchContent_MakeAvailable(glfw3)
+elseif(NOT glfw3_FOUND)
+    message(ERROR " Unable to find GLFW")
+endif()
+
+add_library(vkfw INTERFACE)
+target_include_directories(vkfw INTERFACE
+    $<BUILD_INTERFACE:${VKFW_SOURCE_ROOT}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(vkfw INTERFACE glfw)
+
+function(add_definitions OPTION_NAME)
+    if ("${${OPTION_NAME}}")
+        target_compile_definitions(vkfw INTERFACE "${OPTION_NAME}")
+    endif()
+endfunction()
+
+# Set options. See README.md for the full list.
+add_definitions(VKFW_DISABLE_ENHANCED_MODE)
+add_definitions(VKFW_NO_EXCEPTIONS)
+add_definitions(VKFW_NO_SMART_HANDLE)
+add_definitions(VKFW_NO_STD_FUNCTION_CALLBACKS)
+add_definitions(VKFW_NO_NODISCARD_WARNINGS)
+add_definitions(VKFW_NO_INCLUDE_VULKAN)
+add_definitions(VKFW_INCLUDE_GL)
+add_definitions(VKFW_NO_INCLUDE_VULKAN_HPP)
+add_definitions(VKFW_NO_LEADING_E_IN_ENUMS)
+add_definitions(VKFW_NO_STRUCT_CONSTRUCTORS)
+add_definitions(VKFW_NO_SPACESHIP_OPERATOR)
+add_definitions(VKFW_NO_STRING_VIEW)
+add_definitions(VKFW_NO_SPAN)
+
+if (VKFW_INSTALL)
+    include(CMakePackageConfigHelpers)
+    include(GNUInstallDirs)
+
+    install(TARGETS vkfw
+        EXPORT vkfw
+        LIBRARY DESTINATION lib
+        INCLUDES DESTINATION include
+    )
+
+    install(EXPORT vkfw
+        FILE vkfwTargets.cmake
+        NAMESPACE vkfw::
+        DESTINATION lib/cmake/vkfw
+    )
+
+    install(FILES
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/vkfwConfig.cmake"
+        DESTINATION lib/cmake/vkfw
+    )
+
+    set(VKFW_INSTALL_HEADERS
+        ${VKFW_SOURCE_ROOT}/vkfw/vkfw.hpp
+    )
+
+    install(FILES
+        ${VKFW_INSTALL_HEADERS}
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/vkfw"
+    )
+endif()
+
+if (VKFW_BUILD_EXAMPLES)
+    add_subdirectory(${VKFW_EXAMPLE_ROOT})
+endif()

--- a/README.md
+++ b/README.md
@@ -5,8 +5,30 @@ It focuses on features like type safety with enums and bitfields, STL containers
 If you find any bugs or problems, I'd appreciate an [issue](https://github.com/Cvelth/vkfw/issues).
 
 ## Getting Started
-All you need is to include `vkfw/vkfw.hpp` and you're ready to go.
-That is to say, you still need to link against [glfw](https://github.com/glfw/glfw). These are just bindings, not a full-fledged library.
+There are a few ways in which you can integrate `vkfw` in your project:
+
+1. The easiest way is to copy the header file (`vkfw/vkfw.hpp`) into your source tree and include it. Note that you still need to link against [glfw](https://github.com/glfw/glfw) as these are just bindings, not a full-fledged library.
+2. You can add it as a git submodule and then just:
+    ```cmake
+    add_subdirectory(<path-to-vkfw-dir>)
+    target_link_libraries(<your-project> PRIVATE vkfw)
+    ```
+3. You can also install it system-wide (see `VKFW_INSTALL` option of the provided `CMakeLists.txt` and then do):
+    ```cmake
+    find_package(vkfw REQUIRED)
+    target_link_libraries(<your-project> PRIVATE vkfw::vkfw)
+    ```
+4. You can use `FetchContent`:
+    ```cmake
+    include(FetchContent)
+    FetchContent_Declare(
+        vkfw
+        GIT_REPOSITORY https://github.com/Cvelth/vkfw
+    )
+    FetchContent_MakeAvailable(vkfw)
+    target_link_libraries(<your-project> PRIVATE vkfw::vkfw)
+    ```
+5. You can add a port for it to your private `vcpkg` repository or otherwise adopt it in your preferred package manager. All you need is the `vkfw/vkfw.hpp` header.
 
 ### Minimum Requirements
 VKFW requires a C++11 capable compiler to compile. The following compilers are expected to work:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ As all the deleters are known at compiler time and don't need to store anything 
 To allow using lambdas as callbacks, `GLFWwindow` user pointer is used internally to store `std::function` objects instead of c-style function pointers.
 These objects are accessible through `vkfw::Window::callbacks()` (or `accessWindowCallbacks(GLFWwindow *)` if enhanced mode is disabled) function and can be set directly, for example:
 ```c++
-my_window.callbacks().on_key = [](vkfw::Window const &, vkfw::Key key, int32_t, 
+my_window.callbacks().on_key = [](vkfw::Window const &, vkfw::Key key, int32_t,
                                   vkfw::KeyAction action, vkfw::ModifierKeyFlags) {
   std::cout << vkfw::to_string(action) << ' ' << vkfw::to_string(key) << ".\n";
 };
@@ -125,7 +125,7 @@ In enhanced mode, the last optional parameter of `vkfw::createWindow(..., bool r
 ## Configuration Options
 
 ### `VKFW_DISABLE_ENHANCED_MODE`
-When this is defined before including `vkfw.hpp`, you essentially disable all enhanced functionality. 
+When this is defined before including `vkfw.hpp`, you essentially disable all enhanced functionality.
 
 All you then get is improved compile time error detection, via scoped enums and bitmasks, as well as a compile time checked attribute/hint getters/setters.
 

--- a/cmake/vkfwConfig.cmake
+++ b/cmake/vkfwConfig.cmake
@@ -1,0 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(glfw3 REQUIRED)
+
+include(${CMAKE_CURRENT_LIST_DIR}/vkfwTargets.cmake)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,54 @@
+find_package(OpenGL REQUIRED)
+find_package(Vulkan REQUIRED)
+
+# Under normal circumstances, FetchContent_MakeAvailable will create the GLFW target that
+# other targets can link against. This creates a problem if find_package succeeds, as the
+# target has already been defined, which will cause FetchContent_MakeAvailable to fail.
+# Since it's impossible to get in here without either having found GLFW through
+# find_package or having already fetched it through FetchContent, then all that we need to
+# do is handle the case where FetchContent wasn't used because find_package succeeded.
+# Since all that we want is for GLFW to be cloned so we can access the deps folder, we're
+# going to use FetchContent_Populate instead.
+if (glfw3_FOUND)
+    include(FetchContent)
+    FetchContent_Populate(
+        glfw3
+        GIT_REPOSITORY https://github.com/glfw/glfw
+        GIT_TAG ${VKFW_GLFW_FETCH_VERSION}
+        QUIET
+    )
+endif()
+
+function(add_example NAME)
+    add_executable("${NAME}" WIN32 MACOSX_BUNDLE "${VKFW_EXAMPLE_ROOT}/${NAME}.cpp")
+    target_link_libraries("${NAME}" PRIVATE vkfw glfw Vulkan::Vulkan)
+    target_include_directories("${NAME}" PRIVATE "${glfw3_SOURCE_DIR}/deps")
+    target_compile_features("${NAME}" PRIVATE cxx_std_20)
+
+    if (MSVC OR CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+        target_compile_definitions("${NAME}" PRIVATE _CRT_SECURE_NO_WARNINGS)
+    endif()
+
+    if (MSVC)
+        set_target_properties("${NAME}" PROPERTIES LINK_FLAGS "/ENTRY:mainCRTStartup")
+    elseif (CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+        set_target_properties("${NAME}" PROPERTIES LINK_FLAGS "-Wl,/entry:mainCRTStartup")
+    endif()
+
+    if (APPLE)
+        set_target_properties("${NAME}" PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME "${NAME}")
+    endif()
+endfunction()
+
+add_example(boing)
+add_example(clipboard)
+add_example(cursor)
+add_example(empty)
+add_example(events)
+add_example(gears)
+add_example(heightmap)
+add_example(icon)
+add_example(iconify)
+add_example(offscreen)
+add_example(sharing)
+add_example(windows)

--- a/example/boing.cpp
+++ b/example/boing.cpp
@@ -42,7 +42,8 @@
 
 #include "linmath.h"
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 /*****************************************************************************
@@ -595,7 +596,7 @@ int main(void) {
     window->callbacks()->on_cursor_move = &cursor_position_callback;
 
     window->makeContextCurrent();
-    gladLoadGLLoader((GLADloadproc) &vkfw::getProcAddress);
+    gladLoadGL((GLADloadfunc) &vkfw::getProcAddress);
     vkfw::swapInterval(1);
 
     reshape(*window, window->getFramebufferWidth(), window->getFramebufferHeight());

--- a/example/clipboard.cpp
+++ b/example/clipboard.cpp
@@ -35,7 +35,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 #if defined(__APPLE__)
@@ -83,7 +84,7 @@ int main() {
     auto window = vkfw::createWindowUnique(200, 200, "Clipboard Test", hints);
     window->makeContextCurrent();
 
-    gladLoadGLLoader((GLADloadproc) vkfw::getProcAddress);
+    gladLoadGL((GLADloadfunc) vkfw::getProcAddress);
     vkfw::swapInterval(1);
 
     window->callbacks()->on_key = key_callback;

--- a/example/cursor.cpp
+++ b/example/cursor.cpp
@@ -47,7 +47,8 @@
 
 #include "linmath.h"
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 #define CURSOR_FRAME_COUNT 60
@@ -315,7 +316,7 @@ int CursorExample::run() {
   hints.contextVersionMinor = 0u;
   auto window = vkfw::createWindowUnique(640, 480, "Cursor Test", hints);
   window->makeContextCurrent();
-  gladLoadGLLoader((GLADloadproc) vkfw::getProcAddress);
+  gladLoadGL((GLADloadfunc) vkfw::getProcAddress);
 
   GLuint vertex_buffer, vertex_shader, fragment_shader, program;
   GLint mvp_location, vpos_location;

--- a/example/empty.cpp
+++ b/example/empty.cpp
@@ -36,7 +36,8 @@
 #include <random>
 #include <thread>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 static void error_callback(int, const char *description) {
@@ -59,7 +60,7 @@ int main() {
     };
 
     window->makeContextCurrent();
-    gladLoadGLLoader((GLADloadproc) vkfw::getProcAddress);
+    gladLoadGL((GLADloadfunc) vkfw::getProcAddress);
 
     static volatile bool running = true;
     std::thread thread([]() {

--- a/example/events.cpp
+++ b/example/events.cpp
@@ -43,7 +43,8 @@
 #include <cstring>
 #include <string_view>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 // Event index
@@ -338,7 +339,7 @@ int main(int argc, char **argv) {
       if (once) {
         once = false;
         slots[i].window->makeContextCurrent();
-        gladLoadGLLoader((GLADloadproc) vkfw::getProcAddress);
+        gladLoadGL((GLADloadfunc) vkfw::getProcAddress);
         vkfw::swapInterval(1);
       }
     }

--- a/example/gears.cpp
+++ b/example/gears.cpp
@@ -36,7 +36,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 /**
@@ -295,7 +296,7 @@ int main(int, char *[]) {
     window->callbacks()->on_key = &key;
 
     window->makeContextCurrent();
-    gladLoadGLLoader((GLADloadproc) &vkfw::getProcAddress);
+    gladLoadGL((GLADloadfunc) &vkfw::getProcAddress);
     vkfw::swapInterval(1);
 
     reshape(*window, window->getFramebufferWidth(), window->getFramebufferHeight());

--- a/example/heightmap.cpp
+++ b/example/heightmap.cpp
@@ -34,7 +34,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 /* Map height updates */
@@ -378,7 +379,7 @@ int main(int, char **) {
     };
 
     window->makeContextCurrent();
-    gladLoadGLLoader((GLADloadproc) &vkfw::getProcAddress);
+    gladLoadGL((GLADloadfunc) &vkfw::getProcAddress);
 
     /* Prepare opengl resources for rendering */
     GLuint shader_program = make_shader_program(vertex_shader_text, fragment_shader_text);

--- a/example/icon.cpp
+++ b/example/icon.cpp
@@ -35,7 +35,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 // a simple glfw logo
@@ -98,7 +99,7 @@ int main() {
     hints.clientAPI = vkfw::ClientAPI::eOpenGL;
     auto window = vkfw::createWindowUnique(200, 200, "Window Icon", hints);
     window->makeContextCurrent();
-    gladLoadGLLoader((GLADloadproc) vkfw::getProcAddress);
+    gladLoadGL((GLADloadfunc) vkfw::getProcAddress);
 
     bool is_vkfw = true;
     size_t current_color = 0;

--- a/example/iconify.cpp
+++ b/example/iconify.cpp
@@ -36,7 +36,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 static void usage(void) {
@@ -138,7 +139,7 @@ static auto create_window(vkfw::Monitor const &monitor, bool is_fullscreen) {
   } else
     output = vkfw::createWindowUnique(640, 480, "Iconify", hints, monitor);
   output->makeContextCurrent();
-  gladLoadGLLoader((GLADloadproc) vkfw::getProcAddress);
+  gladLoadGL((GLADloadfunc) vkfw::getProcAddress);
   return output;
 }
 

--- a/example/offscreen.cpp
+++ b/example/offscreen.cpp
@@ -34,7 +34,8 @@
 #include "linmath.h"
 #include "stb_image_write.h"
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 #if USE_NATIVE_OSMESA
@@ -91,7 +92,7 @@ int main(void) {
     auto window = vkfw::createWindowUnique(640, 480, "Simple example", hints);
 
     window->makeContextCurrent();
-    gladLoadGLLoader((GLADloadproc) &vkfw::getProcAddress);
+    gladLoadGL((GLADloadfunc) &vkfw::getProcAddress);
 
     // NOTE: OpenGL error checks have been omitted for brevity
     GLuint vertex_buffer, vertex_shader, fragment_shader, program;

--- a/example/sharing.cpp
+++ b/example/sharing.cpp
@@ -34,7 +34,8 @@
 
 #include "linmath.h"
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 static const char *vertex_shader_text = R"(
@@ -93,7 +94,7 @@ int main() {
 
     // The contexts are created with the same APIs so the function
     // pointers should be re-usable between them
-    gladLoadGLLoader((GLADloadproc) glfwGetProcAddress);
+    gladLoadGL((GLADloadfunc) glfwGetProcAddress);
 
     GLuint texture, program, vertex_buffer;
     GLint mvp_location, color_location, texture_location, vpos_location;

--- a/example/windows.cpp
+++ b/example/windows.cpp
@@ -36,7 +36,8 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "glad/glad.h"
+#define GLAD_GL_IMPLEMENTATION
+#include "glad/gl.h"
 #include "vkfw/vkfw.hpp"
 
 static const char *titles[] = { "Red", "Green", "Blue", "Yellow" };
@@ -106,7 +107,7 @@ int main(int argc, char **argv) {
       static bool once = true;
       if (once) {
         once = false;
-        gladLoadGLLoader((GLADloadproc) vkfw::getProcAddress);
+        gladLoadGL((GLADloadfunc) vkfw::getProcAddress);
       }
 
       glClearColor(colors[i].r, colors[i].g, colors[i].b, 1.f);


### PR DESCRIPTION
Adds full integration with CMake:
* Create CMake targets,
* Allow installation,
* Provide ways of setting the various configuration options at build time,
* Set up examples to be built through CMake.

This did require a few minor tweaks:
* I copied over `glad.h`, `linmath.h`, and `stb_image_write.h` from GLFW's source.
* Examples had to be updated to use the new code.

Other than that, everything was pretty straight-forward. 
I did have one question though: usually, libraries are versioned so that users can link against specific versions of the library. I'm guessing you want to keep `vkfw` unversioned? If not, then I can add the necessary CMake code to capture the version number when the library is installed.