### PR TITLE
Revert "Add backwards compatibility with Vulkan headers 1.3"

### DIFF
--- a/include/vkfw/vkfw.hpp
+++ b/include/vkfw/vkfw.hpp
@@ -3128,13 +3128,9 @@ namespace VKFW_NAMESPACE {
                             Dispatch const& dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT) {
     VkSurfaceKHR output;
     glfwCreateWindowSurface(instance, window, allocator, &output);
-      #ifdef VULKAN_API_VERSION_1_4
+
     vk::detail::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> deleter(instance,
                                                                                         dispatch);
-      #else
-    vk::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> deleter(instance,
-                                                                                dispatch);
-      #endif
     return vk::UniqueSurfaceKHR(output, deleter);
   }
     #endif


### PR DESCRIPTION
Reverts Cvelth/vkfw#17. This change was made in error, and does not compile with either Vulkan header version when the createWindowSurfaceUnique function is actually used. This was my fault, but I would recommend adding unit tests to make sure issues like this do not happen again.