### PR TITLE
Fix `vkfw::raii::Window::set()`

### DIFF
--- a/include/vkfw/vkfw.hpp
+++ b/include/vkfw/vkfw.hpp
@@ -5129,7 +5129,7 @@ namespace VKFW_NAMESPACE {
                 typename = typename std::enable_if<AttributeTraits<attribute>::value>::type>
       VKFW_NODISCARD_WHEN_NO_EXCEPTIONS typename ResultValueType<void>::type
       set(typename AttributeTraits<attribute>::type const &new_value) const {
-        return m_window.set(new_value);
+        return m_window.set<attribute>(new_value);
       }
 
       template <InputMode mode>
@@ -5141,7 +5141,7 @@ namespace VKFW_NAMESPACE {
       template <InputMode mode>
       VKFW_NODISCARD_WHEN_NO_EXCEPTIONS typename ResultValueType<void>::type
       set(typename InputModeTraits<mode>::type const &new_value) const {
-        return m_window.set(new_value);
+        return m_window.set<mode>(new_value);
       }
 
   #ifdef VKFW_NO_STD_FUNCTION_CALLBACKS


### PR DESCRIPTION
As per issue #24 of vkfw.

Given the `vkfw::raii::Window::set()` function:

```cpp
template <InputMode mode>
VKFW_NODISCARD_WHEN_NO_EXCEPTIONS typename ResultValueType<void>::type
set(typename InputModeTraits<mode>::type const &new_value) const {
  return m_window.set(new_value);
}
```

`m_window.set(new_value)` does not work because apparently the `InputMode` template parameter for `m_window.set()` cannot be deduced from `new_value` alone. So, I added an explicit template argument to fix that.

Note that I also added an explicit template argument to the `template <Attribute attribute>` overload of `vkfw::raii::Window::set()` too, because I noticed that that also had the same problem. I didn't mention this in the original issue though.