### PR TITLE
Fix vkfw module while duplicating as little code as possible

### DIFF
--- a/include/vkfw/vkfw.cppm
+++ b/include/vkfw/vkfw.cppm
@@ -1,3 +1,139 @@
+// Copyright (c) 2020 Cvelth.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 module;
+
 #define VKFW_MODULE_IMPLEMENTATION
-#include <vkfw/vkfw.hpp>
+
+#ifdef _MSVC_LANG
+  #define VKFW_CPLUSPLUS _MSVC_LANG
+#else
+  #define VKFW_CPLUSPLUS __cplusplus
+#endif
+
+#if 201703L < VKFW_CPLUSPLUS
+  #define VKFW_CPP_VERSION 20
+#else
+  #error "vkfw.cppm needs at least c++ standard version 20"
+#endif
+
+#ifndef VKFW_INCLUDE_GL
+  #define GLFW_INCLUDE_NONE
+#endif
+#ifndef VKFW_NO_INCLUDE_VULKAN
+  #define GLFW_INCLUDE_VULKAN
+#endif
+#include <GLFW/glfw3.h>
+
+#ifndef VKFW_NO_INCLUDE_VULKAN_HPP
+  #if defined(VKFW_NO_STRUCT_CONSTRUCTORS) && !defined(VULKAN_HPP_NO_STRUCT_CONSTRUCTORS)
+    #define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS VKFW_NO_STRUCT_CONSTRUCTORS
+  #endif
+  #if defined(VKFW_NO_EXCEPTIONS) && !defined(VULKAN_HPP_NO_EXCEPTIONS)
+    #define VULKAN_HPP_NO_EXCEPTIONS VKFW_NO_EXCEPTIONS
+  #endif
+  #if defined(VKFW_NO_NODISCARD_WARNINGS) && !defined(VULKAN_HPP_NO_NODISCARD_WARNINGS)
+    #define VULKAN_HPP_NO_NODISCARD_WARNINGS VKFW_NO_NODISCARD_WARNINGS
+  #endif
+  #if defined(VKFW_ASSERT) && !defined(VULKAN_HPP_ASSERT)
+    #define VULKAN_HPP_ASSERT VKFW_ASSERT
+  #endif
+  #if defined(VKFW_ASSERT_ON_RESULT) && !defined(VULKAN_HPP_ASSERT_ON_RESULT)
+    #define VULKAN_HPP_ASSERT_ON_RESULT VKFW_ASSERT_ON_RESULT
+  #endif
+  #if defined(VKFW_DISABLE_ENHANCED_MODE) && !defined(VULKAN_HPP_DISABLE_ENHANCED_MODE)
+    #define VULKAN_HPP_DISABLE_ENHANCED_MODE VKFW_DISABLE_ENHANCED_MODE
+  #endif
+  #if defined(VKFW_INLINE) && !defined(VULKAN_HPP_INLINE)
+    #define VULKAN_HPP_INLINE VKFW_INLINE
+  #endif
+  #if defined(VKFW_NO_SMART_HANDLE) && !defined(VULKAN_HPP_NO_SMART_HANDLE)
+    #define VULKAN_HPP_NO_SMART_HANDLE VKFW_NO_SMART_HANDLE
+  #endif
+  #ifdef VKFW_ENABLE_VULKAN_HPP_MODULE
+    #include <vulkan/vulkan_hpp_macros.hpp>
+  #else
+    #include <vulkan/vulkan.hpp>
+  #endif
+#endif
+
+#if 20 <= VKFW_CPP_VERSION && defined(__has_include) && __has_include(<version> )
+  #include <version>
+#endif
+#if !defined(VKFW_NO_STRING_VIEW) && 17 <= VKFW_CPP_VERSION
+  #define VKFW_HAS_STRING_VIEW
+  #ifndef VKFW_ENABLE_STD_MODULE
+    #include <string_view>
+  #endif
+#endif
+#if !defined(VKFW_NO_SPAN) && 20 <= VKFW_CPP_VERSION && defined(__cpp_lib_span)                    \
+  && defined(__has_include) && 202002L <= __cpp_lib_span && __has_include(<span> )
+  #define VKFW_HAS_SPAN
+  #ifndef VKFW_ENABLE_STD_MODULE
+    #include <span>
+  #endif
+#endif
+#if !defined(VKFW_NO_SPACESHIP_OPERATOR) && 20 <= VKFW_CPP_VERSION                                 \
+  && defined(__cpp_impl_three_way_comparison) && defined(__has_include)                            \
+  && 201711 <= __cpp_impl_three_way_comparison && __has_include(<compare> )
+  #define VKFW_HAS_SPACESHIP_OPERATOR
+  #ifndef VKFW_ENABLE_STD_MODULE
+    #include <compare>
+  #endif
+#endif
+
+#ifndef VKFW_ENABLE_STD_MODULE
+  #include <cstdint>
+  #include <string>
+  #include <system_error>
+  #include <tuple>
+  #include <vector>
+#endif
+
+#if defined(VULKAN_HPP_NO_SMART_HANDLE) && !defined(VKFW_NO_SMART_HANDLE)                          \
+  && !defined(VKFW_NO_INCLUDE_VULKAN_HPP)
+  #pragma message(                                                                                 \
+    "warning: VKFW_NO_SMART_HANDLE will be defined as vkfw requires Vulkan-HPP handles when "      \
+    "VKFW_NO_INCLUDE_VULKAN_HPP isn't defined. You can silence this warning by defining "          \
+    "VKFW_NO_SMART_HANDLE or VKFW_NO_INCLUDE_VULKAN_HPP before including <vkfw/vkfw.hpp>")
+  #define VKFW_NO_SMART_HANDLE
+#endif
+
+#ifdef VKFW_DISABLE_ENHANCED_MODE
+  #ifndef VKFW_NO_SMART_HANDLE
+    #define VKFW_NO_SMART_HANDLE
+  #endif
+#elif !defined(VKFW_ENABLE_STD_MODULE)
+  #include <algorithm>
+  #include <chrono>
+  #include <iterator>
+  #include <memory>
+#endif
+
+#if !defined(VKFW_NO_STD_FUNCTION_CALLBACKS) && !defined(VKFW_ENABLE_STD_MODULE)
+  #include <functional>
+#endif
+
+#ifndef VKFW_ASSERT
+  #include <cassert>
+  #define VKFW_ASSERT assert
+#endif
+
+export module vkfw;
+
+#ifdef VKFW_ENABLE_VULKAN_HPP_MODULE
+import vulkan_hpp;
+#endif
+
+#ifdef VKFW_ENABLE_STD_MODULE
+  #ifdef VULKAN_HPP_STD_MODULE
+import VULKAN_HPP_STD_MODULE
+  #else
+// use std.compat for maximum compatibility
+import std.compat;
+  #endif
+#endif
+
+#include <vkfw.hpp>

--- a/include/vkfw/vkfw.hpp
+++ b/include/vkfw/vkfw.hpp
@@ -4,139 +4,121 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#ifdef _MSVC_LANG
-  #define VKFW_CPLUSPLUS _MSVC_LANG
-#else
-  #define VKFW_CPLUSPLUS __cplusplus
-#endif
+#ifndef VKFW_MODULE_IMPLEMENTATION
 
-#if 201703L < VKFW_CPLUSPLUS
-  #define VKFW_CPP_VERSION 20
-#elif 201402L < VKFW_CPLUSPLUS
-  #define VKFW_CPP_VERSION 17
-#elif 201103L < VKFW_CPLUSPLUS
-  #define VKFW_CPP_VERSION 14
-#elif 199711L < VKFW_CPLUSPLUS
-  #define VKFW_CPP_VERSION 11
-#else
-  #error "vkfw.hpp needs at least c++ standard version 11"
-#endif
-
-#ifndef VKFW_INCLUDE_GL
-  #define GLFW_INCLUDE_NONE
-#endif
-#ifndef VKFW_NO_INCLUDE_VULKAN
-  #define GLFW_INCLUDE_VULKAN
-#endif
-#include <GLFW/glfw3.h>
-
-#ifndef VKFW_NO_INCLUDE_VULKAN_HPP
-  #if defined(VKFW_NO_STRUCT_CONSTRUCTORS) && !defined(VULKAN_HPP_NO_STRUCT_CONSTRUCTORS)
-    #define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS VKFW_NO_STRUCT_CONSTRUCTORS
-  #endif
-  #if defined(VKFW_NO_EXCEPTIONS) && !defined(VULKAN_HPP_NO_EXCEPTIONS)
-    #define VULKAN_HPP_NO_EXCEPTIONS VKFW_NO_EXCEPTIONS
-  #endif
-  #if defined(VKFW_NO_NODISCARD_WARNINGS) && !defined(VULKAN_HPP_NO_NODISCARD_WARNINGS)
-    #define VULKAN_HPP_NO_NODISCARD_WARNINGS VKFW_NO_NODISCARD_WARNINGS
-  #endif
-  #if defined(VKFW_ASSERT) && !defined(VULKAN_HPP_ASSERT)
-    #define VULKAN_HPP_ASSERT VKFW_ASSERT
-  #endif
-  #if defined(VKFW_ASSERT_ON_RESULT) && !defined(VULKAN_HPP_ASSERT_ON_RESULT)
-    #define VULKAN_HPP_ASSERT_ON_RESULT VKFW_ASSERT_ON_RESULT
-  #endif
-  #if defined(VKFW_DISABLE_ENHANCED_MODE) && !defined(VULKAN_HPP_DISABLE_ENHANCED_MODE)
-    #define VULKAN_HPP_DISABLE_ENHANCED_MODE VKFW_DISABLE_ENHANCED_MODE
-  #endif
-  #if defined(VKFW_INLINE) && !defined(VULKAN_HPP_INLINE)
-    #define VULKAN_HPP_INLINE VKFW_INLINE
-  #endif
-  #if defined(VKFW_NO_SMART_HANDLE) && !defined(VULKAN_HPP_NO_SMART_HANDLE)
-    #define VULKAN_HPP_NO_SMART_HANDLE VKFW_NO_SMART_HANDLE
-  #endif
-  #ifdef VKFW_ENABLE_VULKAN_HPP_MODULE
-    #include <vulkan/vulkan_hpp_macros.hpp>
+  #ifdef _MSVC_LANG
+    #define VKFW_CPLUSPLUS _MSVC_LANG
   #else
+    #define VKFW_CPLUSPLUS __cplusplus
+  #endif
+
+  #if 201703L < VKFW_CPLUSPLUS
+    #define VKFW_CPP_VERSION 20
+  #elif 201402L < VKFW_CPLUSPLUS
+    #define VKFW_CPP_VERSION 17
+  #elif 201103L < VKFW_CPLUSPLUS
+    #define VKFW_CPP_VERSION 14
+  #elif 199711L < VKFW_CPLUSPLUS
+    #define VKFW_CPP_VERSION 11
+  #else
+    #error "vkfw.hpp needs at least c++ standard version 11"
+  #endif
+
+  #ifndef VKFW_INCLUDE_GL
+    #define GLFW_INCLUDE_NONE
+  #endif
+  #ifndef VKFW_NO_INCLUDE_VULKAN
+    #define GLFW_INCLUDE_VULKAN
+  #endif
+  #include <GLFW/glfw3.h>
+
+  #ifndef VKFW_NO_INCLUDE_VULKAN_HPP
+    #if defined(VKFW_NO_STRUCT_CONSTRUCTORS) && !defined(VULKAN_HPP_NO_STRUCT_CONSTRUCTORS)
+      #define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS VKFW_NO_STRUCT_CONSTRUCTORS
+    #endif
+    #if defined(VKFW_NO_EXCEPTIONS) && !defined(VULKAN_HPP_NO_EXCEPTIONS)
+      #define VULKAN_HPP_NO_EXCEPTIONS VKFW_NO_EXCEPTIONS
+    #endif
+    #if defined(VKFW_NO_NODISCARD_WARNINGS) && !defined(VULKAN_HPP_NO_NODISCARD_WARNINGS)
+      #define VULKAN_HPP_NO_NODISCARD_WARNINGS VKFW_NO_NODISCARD_WARNINGS
+    #endif
+    #if defined(VKFW_ASSERT) && !defined(VULKAN_HPP_ASSERT)
+      #define VULKAN_HPP_ASSERT VKFW_ASSERT
+    #endif
+    #if defined(VKFW_ASSERT_ON_RESULT) && !defined(VULKAN_HPP_ASSERT_ON_RESULT)
+      #define VULKAN_HPP_ASSERT_ON_RESULT VKFW_ASSERT_ON_RESULT
+    #endif
+    #if defined(VKFW_DISABLE_ENHANCED_MODE) && !defined(VULKAN_HPP_DISABLE_ENHANCED_MODE)
+      #define VULKAN_HPP_DISABLE_ENHANCED_MODE VKFW_DISABLE_ENHANCED_MODE
+    #endif
+    #if defined(VKFW_INLINE) && !defined(VULKAN_HPP_INLINE)
+      #define VULKAN_HPP_INLINE VKFW_INLINE
+    #endif
+    #if defined(VKFW_NO_SMART_HANDLE) && !defined(VULKAN_HPP_NO_SMART_HANDLE)
+      #define VULKAN_HPP_NO_SMART_HANDLE VKFW_NO_SMART_HANDLE
+    #endif
     #include <vulkan/vulkan.hpp>
   #endif
-#endif
 
-#if 20 <= VKFW_CPP_VERSION && defined(__has_include) && __has_include(<version> )
-  #include <version>
-#endif
-#if !defined(VKFW_NO_STRING_VIEW) && 17 <= VKFW_CPP_VERSION
-  #define VKFW_HAS_STRING_VIEW
-  #ifndef VKFW_ENABLE_STD_MODULE
+  #if 20 <= VKFW_CPP_VERSION && defined(__has_include) && __has_include(<version> )
+    #include <version>
+  #endif
+  #if !defined(VKFW_NO_STRING_VIEW) && 17 <= VKFW_CPP_VERSION
+    #define VKFW_HAS_STRING_VIEW
     #include <string_view>
   #endif
-#endif
-#if !defined(VKFW_NO_SPAN) && 20 <= VKFW_CPP_VERSION && defined(__cpp_lib_span)                    \
-  && defined(__has_include) && 202002L <= __cpp_lib_span && __has_include(<span> )
-  #define VKFW_HAS_SPAN
-  #ifndef VKFW_ENABLE_STD_MODULE
+  #if !defined(VKFW_NO_SPAN) && 20 <= VKFW_CPP_VERSION && defined(__cpp_lib_span)                  \
+    && defined(__has_include) && 202002L <= __cpp_lib_span && __has_include(<span> )
+    #define VKFW_HAS_SPAN
     #include <span>
   #endif
-#endif
-#if !defined(VKFW_NO_SPACESHIP_OPERATOR) && 20 <= VKFW_CPP_VERSION                                 \
-  && defined(__cpp_impl_three_way_comparison) && defined(__has_include)                            \
-  && 201711 <= __cpp_impl_three_way_comparison && __has_include(<compare> )
-  #define VKFW_HAS_SPACESHIP_OPERATOR
-  #ifndef VKFW_ENABLE_STD_MODULE
+  #if !defined(VKFW_NO_SPACESHIP_OPERATOR) && 20 <= VKFW_CPP_VERSION                               \
+    && defined(__cpp_impl_three_way_comparison) && defined(__has_include)                          \
+    && 201711 <= __cpp_impl_three_way_comparison && __has_include(<compare> )
+    #define VKFW_HAS_SPACESHIP_OPERATOR
     #include <compare>
   #endif
-#endif
 
-#ifndef VKFW_ENABLE_STD_MODULE
   #include <cstdint>
   #include <string>
   #include <system_error>
   #include <tuple>
   #include <vector>
-#endif
 
-#if defined(VULKAN_HPP_NO_SMART_HANDLE) && !defined(VKFW_NO_SMART_HANDLE)                          \
-  && !defined(VKFW_NO_INCLUDE_VULKAN_HPP)
-  #pragma message(                                                                                 \
-    "warning: VKFW_NO_SMART_HANDLE will be defined as vkfw requires Vulkan-HPP handles when "      \
-    "VKFW_NO_INCLUDE_VULKAN_HPP isn't defined. You can silence this warning by defining "          \
-    "VKFW_NO_SMART_HANDLE or VKFW_NO_INCLUDE_VULKAN_HPP before including <vkfw/vkfw.hpp>")
-  #define VKFW_NO_SMART_HANDLE
-#endif
-
-#ifdef VKFW_DISABLE_ENHANCED_MODE
-  #ifndef VKFW_NO_SMART_HANDLE
+  #if defined(VULKAN_HPP_NO_SMART_HANDLE) && !defined(VKFW_NO_SMART_HANDLE)                        \
+    && !defined(VKFW_NO_INCLUDE_VULKAN_HPP)
+    #pragma message(                                                                               \
+      "warning: VKFW_NO_SMART_HANDLE will be defined as vkfw requires Vulkan-HPP handles when "    \
+      "VKFW_NO_INCLUDE_VULKAN_HPP isn't defined. You can silence this warning by defining "        \
+      "VKFW_NO_SMART_HANDLE or VKFW_NO_INCLUDE_VULKAN_HPP before including <vkfw/vkfw.hpp>")
     #define VKFW_NO_SMART_HANDLE
   #endif
-#elif !defined(VKFW_ENABLE_STD_MODULE)
-  #include <algorithm>
-  #include <chrono>
-  #include <iterator>
-  #include <memory>
-#endif
 
-#if !defined(VKFW_NO_STD_FUNCTION_CALLBACKS) && !defined(VKFW_ENABLE_STD_MODULE)
-  #include <functional>
-#endif
+  #ifdef VKFW_DISABLE_ENHANCED_MODE
+    #ifndef VKFW_NO_SMART_HANDLE
+      #define VKFW_NO_SMART_HANDLE
+    #endif
+  #else
+    #include <algorithm>
+    #include <chrono>
+    #include <iterator>
+    #include <memory>
+  #endif
 
-#ifndef VKFW_ASSERT
-  #include <cassert>
-  #define VKFW_ASSERT assert
-#endif
+  #ifndef VKFW_NO_STD_FUNCTION_CALLBACKS
+    #include <functional>
+  #endif
+
+  #ifndef VKFW_ASSERT
+    #include <cassert>
+    #define VKFW_ASSERT assert
+  #endif
+
+#endif // !defined(VKFW_MODULE_IMPLEMENTATION)
 
 #ifndef VKFW_ASSERT_ON_RESULT
   #define VKFW_ASSERT_ON_RESULT VKFW_ASSERT
 #endif
-
-#define VKFW_VERSION_MAJOR             0
-#define VKFW_VERSION_MINOR             2
-#define VKFW_VERSION_PATCH             0
-#define VKFW_TARGET_GLFW_VERSION_MAJOR 3
-#define VKFW_TARGET_GLFW_VERSION_MINOR 4
-
-static_assert(GLFW_VERSION_MAJOR == VKFW_TARGET_GLFW_VERSION_MAJOR
-                && GLFW_VERSION_MINOR == VKFW_TARGET_GLFW_VERSION_MINOR,
-              "\"glfw3.h\" version is not compatible with the \"vkfw.hpp\" version!");
 
 #ifndef VKFW_INLINE
   #ifdef __clang__
@@ -215,25 +197,18 @@ static_assert(GLFW_VERSION_MAJOR == VKFW_TARGET_GLFW_VERSION_MAJOR
   #define VKFW_ENUMERATOR2(name_1, name_2) e##name_1
 #endif
 
-#ifdef VKFW_MODULE_IMPLEMENTATION
-export module vkfw;
-#endif
+#define VKFW_VERSION_MAJOR             0
+#define VKFW_VERSION_MINOR             2
+#define VKFW_VERSION_PATCH             0
+#define VKFW_TARGET_GLFW_VERSION_MAJOR 3
+#define VKFW_TARGET_GLFW_VERSION_MINOR 4
 
-#ifdef VKFW_ENABLE_VULKAN_HPP_MODULE
-import vulkan_hpp;
-#endif
-
-#ifdef VKFW_ENABLE_STD_MODULE
-  #ifdef VULKAN_HPP_STD_MODULE
-import VULKAN_HPP_STD_MODULE
-  #else
-// use std.compat for maximum compatibility
-import std.compat;
-  #endif
-#endif
+static_assert(GLFW_VERSION_MAJOR == VKFW_TARGET_GLFW_VERSION_MAJOR
+                && GLFW_VERSION_MINOR == VKFW_TARGET_GLFW_VERSION_MINOR,
+              "\"glfw3.h\" version is not compatible with the \"vkfw.hpp\" version!");
 
 #ifdef VKFW_MODULE_IMPLEMENTATION
-  export namespace VKFW_NAMESPACE {
+export namespace VKFW_NAMESPACE {
 #else
 namespace VKFW_NAMESPACE {
 #endif
@@ -3911,7 +3886,7 @@ namespace VKFW_NAMESPACE {
                          [](char const *path) { return std::string_view{ path }; });
           ptr->on_drop(window, std::move(output));
     #else
-					ptr->on_drop(window, std::vector<char const *>(paths, paths + path_count));
+                    ptr->on_drop(window, std::vector<char const *>(paths, paths + path_count));
     #endif
         }
       });


### PR DESCRIPTION
### Changes
1. Shrinks the global module fragment (the part after `module;` but before `export module ...`), leaving mostly only C++ version checks and `#include`'s.
2. Duplicates said fragment to vkfw.cppm to avoid errors.
3. Removes `vkfw.cppm`-only code from `vkfw.hpp` and `vkfw.hpp`-only code from `vkfw.cppm` in said fragment (and header counterpart of said fragment).

### Known issue
Including a header (`vkfw.hpp`) in the purview of a module (after `export module ...`) is technically not allowed, and gives off a warning. However, everyone still does that, even standard library implementations, and they usually sillence the warning. I didn't.