### PR TITLE
Improve the VKFW_INLINE implementation using C++11 attributes

### DIFF
--- a/include/vkfw/vkfw.hpp
+++ b/include/vkfw/vkfw.hpp
@@ -139,19 +139,7 @@ static_assert(GLFW_VERSION_MAJOR == VKFW_TARGET_GLFW_VERSION_MAJOR
               "\"glfw3.h\" version is not compatible with the \"vkfw.hpp\" version!");
 
 #ifndef VKFW_INLINE
-  #ifdef __clang__
-    #if __has_attribute(always_inline)
-      #define VKFW_INLINE __attribute__((always_inline)) __inline__
-    #else
-      #define VKFW_INLINE inline
-    #endif
-  #elif defined(__GNUC__)
-    #define VKFW_INLINE __attribute__((always_inline)) __inline__
-  #elif defined(_MSC_VER)
-    #define VKFW_INLINE inline
-  #else
-    #define VKFW_INLINE inline
-  #endif
+  #define VKFW_INLINE [[gnu::always_inline, clang::always_inline, msvc::forceinline]] inline
 #endif
 
 #ifdef __cpp_constexpr


### PR DESCRIPTION
### Old
```
#ifndef VKFW_INLINE
  #ifdef __clang__
    #if __has_attribute(always_inline)
      #define VKFW_INLINE __attribute__((always_inline)) __inline__
    #else
      #define VKFW_INLINE inline
    #endif
  #elif defined(__GNUC__)
    #define VKFW_INLINE __attribute__((always_inline)) __inline__
  #elif defined(_MSC_VER)
    #define VKFW_INLINE inline
  #else
    #define VKFW_INLINE inline
  #endif
#endif
```
The usual solution. It works, but is hard to read and understand. Also, kind of weird that an always-inline trait for MSVC (like `__forceinline`) isn't used.

### New
```
#ifndef VKFW_INLINE
  #define VKFW_INLINE [[gnu::always_inline, clang::always_inline, msvc::forceinline]] inline
#endif
```

- Cleaner and easier to read
- Basically 1 line
- Easy to see which compilers have an always-inline trait is implemented for
- Backup `inline` for other compilers
- `[[attributes]]` are automatically supported anyway, since this project has a minimum of C++11.